### PR TITLE
Use task in the note about how methods names need to match task names

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -300,7 +300,7 @@ email_summarizer:
 ```
 
 <Tip>
-  Note how we use the same name for the agent in the `tasks.yaml` (`email_summarizer_task`) file as the method name in the `crew.py` (`email_summarizer_task`) file.
+  Note how we use the same name for the task in the `tasks.yaml` (`email_summarizer_task`) file as the method name in the `crew.py` (`email_summarizer_task`) file.
 </Tip>
 
 ```yaml tasks.yaml


### PR DESCRIPTION
The note is about `task` but mentions `agent` incorrectly.